### PR TITLE
Change instantiations in constructor

### DIFF
--- a/KokoApp.ts
+++ b/KokoApp.ts
@@ -94,27 +94,27 @@ export class KokoApp extends App implements IUIKitInteractionHandler {
     /**
      * The praise mechanism
      */
-    public readonly kokoPraise: KokoPraise;
+    public kokoPraise: KokoPraise;
 
     /**
      * The question mechanism
      */
-    public readonly kokoQuestion: KokoQuestion;
+    public kokoQuestion: KokoQuestion;
 
     /**
      * The values mechanism
      */
-    public readonly kokoValues: KokoValues;
+    public kokoValues: KokoValues;
 
     /**
      * The random one on one mechanism
      */
-    public readonly kokoOneOnOne: KokoOneOnOne;
+    public kokoOneOnOne: KokoOneOnOne;
 
     /**
      * The wellness mechanism
      */
-    public readonly kokoWellness: KokoWellness;
+    public kokoWellness: KokoWellness;
 
     /**
      * Members cache
@@ -124,11 +124,6 @@ export class KokoApp extends App implements IUIKitInteractionHandler {
 
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
-        this.kokoPraise = new KokoPraise(this);
-        this.kokoQuestion = new KokoQuestion(this);
-        this.kokoOneOnOne = new KokoOneOnOne(this);
-        this.kokoWellness = new KokoWellness(this);
-        this.kokoValues = new KokoValues(this);
     }
 
     /**
@@ -175,6 +170,14 @@ export class KokoApp extends App implements IUIKitInteractionHandler {
         return {
             success: true,
         };
+    }
+
+    public async initialize(configurationExtend: IConfigurationExtend, environmentRead: IEnvironmentRead): Promise<void> {
+        this.kokoPraise = new KokoPraise(this);
+        this.kokoQuestion = new KokoQuestion(this);
+        this.kokoOneOnOne = new KokoOneOnOne(this);
+        this.kokoWellness = new KokoWellness(this);
+        this.kokoValues = new KokoValues(this);
     }
 
     /**

--- a/KokoApp.ts
+++ b/KokoApp.ts
@@ -178,6 +178,8 @@ export class KokoApp extends App implements IUIKitInteractionHandler {
         this.kokoOneOnOne = new KokoOneOnOne(this);
         this.kokoWellness = new KokoWellness(this);
         this.kokoValues = new KokoValues(this);
+
+        await this.extendConfiguration(configurationExtend);
     }
 
     /**


### PR DESCRIPTION
Using the constructor to instantiate the custom classes from the various Koko functionalities was causing the CLI's compiler to error saying their names were not constructors.

The cause for this still needs to be investigated.

In the meanwhile, I've moved the instantiations to be made in the `initialize` app lifecycle method
