### PR TITLE
new: ask questions on-demand

### DIFF
--- a/KokoApp.ts
+++ b/KokoApp.ts
@@ -40,6 +40,7 @@ import { questionModal } from './modals/QuestionModal';
 import { valuesModal } from './modals/ValuesModal';
 import { settings } from './settings';
 import { KokoSend } from './actions/KokoSend';
+import { KokoAskQuestion } from './actions/KokoAskQuestion';
 
 export class KokoApp extends App implements IUIKitInteractionHandler {
 	/**
@@ -103,6 +104,11 @@ export class KokoApp extends App implements IUIKitInteractionHandler {
 	public kokoQuestion: KokoQuestion;
 
 	/**
+	 * The question ask mechanism
+	 */
+	public kokoQuestionAsk: KokoAskQuestion;
+
+	/**
 	 * The values mechanism
 	 */
 	public kokoValues: KokoValues;
@@ -154,6 +160,14 @@ export class KokoApp extends App implements IUIKitInteractionHandler {
 				return this.kokoValues.submit({ context, modify, read, persistence, http });
 			case 'send':
 				return this.kokoSend.submit({ context, modify, read, persistence, http });
+			case 'question-ask-modal':
+				return this.kokoQuestionAsk.submit({
+					context,
+					modify,
+					read,
+					persistence,
+					http,
+				});
 		}
 		return {
 			success: true,
@@ -204,6 +218,7 @@ export class KokoApp extends App implements IUIKitInteractionHandler {
 		this.kokoWellness = new KokoWellness(this);
 		this.kokoValues = new KokoValues(this);
 		this.kokoSend = new KokoSend(this);
+		this.kokoQuestionAsk = new KokoAskQuestion(this);
 
 		await this.extendConfiguration(configurationExtend);
 	}

--- a/KokoApp.ts
+++ b/KokoApp.ts
@@ -500,12 +500,13 @@ export class KokoApp extends App implements IUIKitInteractionHandler, IPostMessa
 			}
 
 			const responsePayload: ResponsePayload = {
-				response: message.text as string,
+				response: message.text,
 				questionId,
 				questionText: parsedText,
 				userId: message.sender.id,
 				roomId: message.room.id,
 				msgId: message.id as string,
+				attachments: message.attachments,
 			};
 
 			// Save the response

--- a/actions/KokoAskQuestion.ts
+++ b/actions/KokoAskQuestion.ts
@@ -51,7 +51,7 @@ export class KokoAskQuestion {
 		}
 
 		try {
-			// 1) Persist the question
+			// Persist the question
 			const questionData: QuestionPayload = {
 				text: questionText,
 				collectionDate,
@@ -71,11 +71,11 @@ export class KokoAskQuestion {
 			const assoc = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, questionAssocId);
 			await persistence.updateByAssociation(assoc, questionData, true);
 
-			// 2) Schedule a one‑time job at the given date
+			// Schedule a one‑time job at the given date
 			await modify.getScheduler().scheduleOnce({
-				id: 'ask-question', // matches your processor
+				id: 'ask-question',
 				when: new Date(sendTime),
-				data: { questionAssocId }, // so your processor knows which question
+				data: { questionAssocId },
 			});
 
 			// 3) Show confirmation
@@ -98,7 +98,7 @@ export class KokoAskQuestion {
 		}
 
 		try {
-			// 1) Load the saved question
+			// Load the saved question
 			const assoc = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, questionAssocId);
 			const [saved] = (await read.getPersistenceReader().readByAssociation(assoc)) as QuestionPayload[];
 
@@ -108,7 +108,7 @@ export class KokoAskQuestion {
 
 			const { text: questionText, collectionDate } = saved;
 
-			// 2) Helper to format the deadline
+			// Helper to format the deadline
 			const formatDate = (dateString: string): string => {
 				const date = new Date(dateString);
 				return new Intl.DateTimeFormat('en-US', {
@@ -124,7 +124,7 @@ export class KokoAskQuestion {
 			};
 			const formattedDate = formatDate(collectionDate);
 
-			// 3) Fetch members and send
+			// Fetch members and send
 			const members = await getMembers(this.app, read);
 			const messageIds: string[] = [];
 			const finisher = modify.getCreator();
@@ -138,8 +138,8 @@ export class KokoAskQuestion {
 					continue;
 				}
 
-				// — First, the highlighted question
-				const highlightedText = `*${questionText}*`;
+				// First, the highlighted question
+				const highlightedText = `*${questionText.trim()}*`;
 				const firstMsg = finisher
 					.startMessage()
 					.setSender(this.app.botUser)
@@ -151,7 +151,7 @@ export class KokoAskQuestion {
 				const msgId = await finisher.finish(firstMsg);
 				messageIds.push(msgId);
 
-				// — Then, the deadline/top‐level info (no thread)
+				// Then, the deadline/top‐level info (in thread)
 				const infoMsg = finisher
 					.startMessage()
 					.setSender(this.app.botUser)
@@ -162,7 +162,7 @@ export class KokoAskQuestion {
 				await finisher.finish(infoMsg);
 			}
 
-			// 4) Persist the sent message IDs and mark “sent”
+			// Persist the sent message IDs and mark “sent”
 			saved.msgIds = messageIds;
 			saved.state = 'sent';
 			await persistence.updateByAssociation(assoc, saved, true);

--- a/actions/KokoAskQuestion.ts
+++ b/actions/KokoAskQuestion.ts
@@ -1,0 +1,193 @@
+import { IHttp, IModify, IPersistence, IRead } from '@rocket.chat/apps-engine/definition/accessors';
+import { IRoom } from '@rocket.chat/apps-engine/definition/rooms';
+import { UIKitViewSubmitInteractionContext } from '@rocket.chat/apps-engine/definition/uikit';
+import { IUser } from '@rocket.chat/apps-engine/definition/users';
+import { RocketChatAssociationModel, RocketChatAssociationRecord } from '@rocket.chat/apps-engine/definition/metadata';
+
+import { KokoApp } from '../KokoApp';
+import { getDirect, getMembers, sendMessage } from '../lib/helpers';
+import { questionSubmittedModal } from '../modals/QuestionAskModal';
+import { createQuestionBlocks } from '../blocks/QuestionBlocks';
+
+export class KokoAskQuestion {
+	constructor(private readonly app: KokoApp) {}
+
+	/**
+	 * Handles the submit action for the Ask Question modal
+	 * Validates input and sends question to all members
+	 */
+	public async submit({
+		context,
+		modify,
+		read,
+		persistence,
+		http,
+	}: {
+		context: UIKitViewSubmitInteractionContext;
+		modify: IModify;
+		read: IRead;
+		persistence: IPersistence;
+		http: IHttp;
+	}) {
+		const data = context.getInteractionData();
+		const { state } = data.view;
+
+		if (!state) {
+			return context.getInteractionResponder().viewErrorResponse({
+				viewId: data.view.id,
+				errors: {
+					'question-input-block': 'Invalid state data. Please try again.',
+				},
+			});
+		}
+
+		// Extract values from the correct state structure
+		const questionText = state['question-input-block']?.['question-input-action'];
+		const collectionDate = state['question-date-block']?.['question-date-action'];
+
+		// Validate question
+		if (!questionText?.trim()) {
+			return context.getInteractionResponder().viewErrorResponse({
+				viewId: data.view.id,
+				errors: {
+					'question-input-block': 'Please enter a question to ask',
+				},
+			});
+		}
+
+		try {
+			// Get all members
+			const members = await getMembers(this.app, read);
+			if (!members || members.length === 0) {
+				throw new Error('No members found to send the question to');
+			}
+
+			// Save question to persistence
+			const questionData = {
+				text: questionText,
+				collectionDate,
+				askedBy: data.user.id,
+				timestamp: new Date().toISOString(),
+			};
+
+			// maybe generate a unique hash for the question
+			const questionId = btoa(`${questionText}_${collectionDate}_${data.user.id}`);
+
+			const assocQuestion = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, questionId);
+			await persistence.updateByAssociation(assocQuestion, questionData, true);
+
+			// Send question to each member
+			for (const member of members) {
+				if (member.id === this.app.botUser?.id) {
+					continue;
+				}
+
+				const formatDate = (dateString: string): string => {
+					const date = new Date(dateString);
+					return new Intl.DateTimeFormat('en-US', {
+						weekday: 'short',
+						month: 'short',
+						day: 'numeric',
+						year: 'numeric',
+						hour: 'numeric',
+						minute: 'numeric',
+						timeZone: 'UTC',
+					}).format(date);
+				};
+
+				const room = await getDirect(this.app, read, modify, member.username);
+				if (room) {
+					const formattedDate = formatDate(collectionDate);
+					const highlightedText = `*${questionText}*`;
+
+					// First message with the question
+					const finisher = modify.getCreator();
+					const msg = finisher
+						.startMessage()
+						.setSender(this.app.botUser)
+						.setUsernameAlias(this.app.kokoName)
+						.setEmojiAvatar(this.app.kokoEmojiAvatar)
+						.setRoom(room)
+						.setText(highlightedText);
+
+					// Send the message
+					const msgId = await finisher.finish(msg);
+
+					// Second message with formatted deadline info
+					const infoMsg = finisher
+						.startMessage()
+						.setSender(this.app.botUser)
+						.setRoom(room)
+						.setText(`*Deadline:* ${formattedDate}\nReply in this thread to submit your answer`)
+						.setThreadId(msgId);
+
+					await finisher.finish(infoMsg);
+				}
+			}
+
+			// Show confirmation modal
+			const modal = questionSubmittedModal(this.app.getID(), questionText);
+			return context.getInteractionResponder().updateModalViewResponse(modal);
+		} catch (error) {
+			this.app.getLogger().error(`Error in ask question command: ${error.message}`);
+
+			return context.getInteractionResponder().viewErrorResponse({
+				viewId: data.view.id,
+				errors: {
+					'question-input-block': 'An error occurred while sending your question. Please try again.',
+				},
+			});
+		}
+	}
+
+	/**
+	 * Broadcasts a question to all members
+	 */
+	public async run(read: IRead, modify: IModify, persistence: IPersistence, question?: string) {
+		if (!this.app.botUser || !this.app.kokoMembersRoom) {
+			return;
+		}
+
+		try {
+			const members = await getMembers(this.app, read);
+			if (!members || members.length === 0) {
+				throw new Error('No members found to send the question to');
+			}
+
+			const questionText = question || 'Default question text';
+
+			// Send question to each member
+			for (const member of members) {
+				if (member.id === this.app.botUser.id) {
+					continue;
+				}
+
+				const room = await getDirect(this.app, read, modify, member.username);
+				if (room) {
+					const blocks = createQuestionBlocks(modify, questionText);
+					await sendMessage(this.app, modify, room, questionText, [], blocks);
+				}
+			}
+		} catch (error) {
+			this.app.getLogger().error(`Error in ask question run method: ${error.message}`);
+		}
+	}
+
+	/**
+	 * Collects and processes responses for a question
+	 */
+	public async collectResponses(read: IRead, persistence: IPersistence, questionId: string) {
+		try {
+			const assocQuestion = new RocketChatAssociationRecord(
+				RocketChatAssociationModel.MISC,
+				`asked_question_${questionId}`,
+			);
+
+			const responses = await read.getPersistenceReader().readByAssociation(assocQuestion);
+			return responses;
+		} catch (error) {
+			this.app.getLogger().error(`Error collecting responses: ${error.message}`);
+			return null;
+		}
+	}
+}

--- a/actions/KokoAskQuestion.ts
+++ b/actions/KokoAskQuestion.ts
@@ -45,7 +45,19 @@ export class KokoAskQuestion {
 			return context.getInteractionResponder().viewErrorResponse({
 				viewId: data.view.id,
 				errors: {
-					'question-input-block': 'Please enter a question to ask',
+					'question-input-action': 'Please enter a question to ask',
+				},
+			});
+		}
+
+		// Check if the date is valid and in the future
+		const today = new Date();
+
+		if (!collectionDate || new Date(collectionDate) < today) {
+			return context.getInteractionResponder().viewErrorResponse({
+				viewId: data.view.id,
+				errors: {
+					'question-input-action': 'Please select a valid date in the future',
 				},
 			});
 		}

--- a/app.json
+++ b/app.json
@@ -13,7 +13,8 @@
     "classFile": "KokoApp.ts",
     "description": "Rocket.Chat Koko Bot",
     "implements": [
-        "IUIKitInteractionHandler"
+        "IUIKitInteractionHandler",
+        "IPostMessageSent"
     ],
     "permissions": [
         {

--- a/app.json
+++ b/app.json
@@ -52,6 +52,9 @@
         },
         {
             "name": "persistence"
+        },
+        {
+            "name": "server-setting.read"
         }
     ]
 }

--- a/commands/Question.ts
+++ b/commands/Question.ts
@@ -2,6 +2,8 @@ import { IModify, IPersistence, IRead } from '@rocket.chat/apps-engine/definitio
 import { SlashCommandContext } from '@rocket.chat/apps-engine/definition/slashcommands';
 import { KokoApp } from '../KokoApp';
 import { questionModal } from '../modals/QuestionModal';
+import { hasValidRole } from '../lib/helpers';
+import { getQuestionAskModal } from '../modals/QuestionAskModal';
 
 // tslint:disable-next-line:max-line-length
 export async function processQuestionCommand(
@@ -12,8 +14,17 @@ export async function processQuestionCommand(
 	persistence: IPersistence,
 ): Promise<void> {
 	const triggerId = context.getTriggerId();
+	const sender = context.getSender();
+	const room = context.getRoom();
+
 	if (triggerId) {
 		try {
+			if (await hasValidRole(read, sender.roles, app.managerRolesMap)) {
+				// Handle the manager role show them a Modal to ship the question
+				const questionAskModal = getQuestionAskModal(app.getID());
+				await modify.getUiController().openSurfaceView(questionAskModal, { triggerId }, context.getSender());
+				return;
+			}
 			const modal = await questionModal({ read, modify, data: { user: context.getSender() } });
 			await modify.getUiController().openModalView(modal, { triggerId }, context.getSender());
 		} catch (error) {

--- a/lib/AskQuestionHelper.ts
+++ b/lib/AskQuestionHelper.ts
@@ -1,0 +1,83 @@
+import { IMessage } from '@rocket.chat/apps-engine/definition/messages';
+import { IUser } from '@rocket.chat/apps-engine/definition/users';
+import { RocketChatAssociationModel, RocketChatAssociationRecord } from '@rocket.chat/apps-engine/definition/metadata';
+import { IRead } from '@rocket.chat/apps-engine/definition/accessors';
+import { QuestionPayload } from '../types/AskQuestion';
+
+export class AskQuestionHelper {
+	/**
+	 * Checks if the message is intended for the bot and eligible for processing.
+	 *
+	 * @param message - The message to check.
+	 * @param appUser - The bot user associated with the app.
+	 * @returns True if the message is eligible, false otherwise.
+	 */
+	public static isMessageIntendedForBot(message: IMessage, appUser: IUser | undefined): boolean {
+		return !!(
+			message.threadId && // Ensure the message is part of a thread
+			message.text && // Ensure the message has text
+			appUser && // Ensure the app user is defined
+			message.sender.id !== appUser.id && // Exclude messages sent by the bot itself
+			message.room.userIds?.includes(appUser.id) && // Ensure the bot is part of the room
+			!message.sender.roles?.includes('bot') && // Exclude messages sent by other bots
+			!message.sender.roles?.includes('app') // Exclude messages sent by other apps
+		);
+	}
+
+	/**
+	 * Validates the parent message.
+	 *
+	 * @param parentMessage - The parent message to validate.
+	 * @param botUserId - The bot user's ID.
+	 * @returns True if the parent message is valid, false otherwise.
+	 */
+	public static isParentMessageValid(parentMessage: IMessage | undefined, botUserId: string): boolean {
+		return !!(parentMessage && parentMessage.text && parentMessage.sender.id === botUserId);
+	}
+
+	/**
+	 * Parses the message text to remove bold formatting.
+	 *
+	 * @param text - The text to parse.
+	 * @returns The parsed text.
+	 */
+	public static parseMessageText(text: string): string {
+		return text.replace(/^\*+|\*+$/g, '').trim();
+	}
+
+	/**
+	 * Generates a question ID based on the parsed text.
+	 *
+	 * @param parsedText - The parsed text of the question.
+	 * @returns The generated question ID.
+	 */
+	public static generateQuestionId(parsedText: string): string {
+		const questionEncoded = Buffer.from(parsedText, 'utf-8').toString('base64');
+		return `question_${questionEncoded}`;
+	}
+
+	/**
+	 * Fetches question associations from persistence.
+	 *
+	 * @param read - The IRead accessor.
+	 * @param questionId - The question ID to fetch associations for.
+	 * @returns A promise resolving to an array of QuestionPayload.
+	 */
+	public static async getQuestionAssociations(read: IRead, questionId: string): Promise<QuestionPayload[]> {
+		return (await read
+			.getPersistenceReader()
+			.readByAssociation(
+				new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, questionId),
+			)) as QuestionPayload[];
+	}
+
+	/**
+	 * Checks if the question date has expired.
+	 *
+	 * @param questionDate - The date of the question.
+	 * @returns True if the question date has expired, false otherwise.
+	 */
+	public static isQuestionExpired(questionDate: Date): boolean {
+		return new Date() > questionDate;
+	}
+}

--- a/lib/AskQuestionHelper.ts
+++ b/lib/AskQuestionHelper.ts
@@ -15,7 +15,6 @@ export class AskQuestionHelper {
 	public static isMessageIntendedForBot(message: IMessage, appUser: IUser | undefined): boolean {
 		return !!(
 			message.threadId && // Ensure the message is part of a thread
-			message.text && // Ensure the message has text
 			appUser && // Ensure the app user is defined
 			message.sender.id !== appUser.id && // Exclude messages sent by the bot itself
 			message.room.userIds?.includes(appUser.id) && // Ensure the bot is part of the room

--- a/modals/QuestionAskModal.ts
+++ b/modals/QuestionAskModal.ts
@@ -2,50 +2,58 @@ import { IUIKitSurfaceViewParam } from '@rocket.chat/apps-engine/definition/acce
 import { UIKitSurfaceType } from '@rocket.chat/apps-engine/definition/uikit';
 import { BlockElementType, ButtonElement, LayoutBlock } from '@rocket.chat/ui-kit';
 
-const ASK_Q_MODAL_IDS = {
-	QUESTION_ASK: 'question-ask-modal',
-} as const;
-
-const ASK_Q_ACTION_IDS = {
-	QUESTION_INPUT: 'question-input-action',
-	QUESTION_DATE: 'question-date-action',
-	SUBMIT_QUESTION: 'submit-question',
-	CLOSE_MODAL: 'close-modal',
-} as const;
-
-const ASK_Q_BLOCK_IDS = {
-	QUESTION_INPUT: 'question-input-block',
-	QUESTION_DATE: 'question-date-block',
-} as const;
-
-const ASK_Q_TEXT = {
-	labels: {
-		QUESTION_INPUT: 'Question to ask',
-		QUESTION_DATE: 'Collection date',
+const QUESTION_CONSTANTS = {
+	MODAL_IDS: {
+		QUESTION_ASK: 'question-ask-modal',
 	},
-	placeholders: {
-		QUESTION_INPUT: 'Type your question here...',
-		QUESTION_DATE: 'Select collection date',
+	ACTION_IDS: {
+		QUESTION_INPUT: 'question-input-action',
+		QUESTION_DATE: 'question-date-action',
+		SUBMIT_QUESTION: 'submit-question',
+		CLOSE_MODAL: 'close-modal',
 	},
-	titles: {
-		QUESTION_ASK: 'Send Question to Members',
-		CANCEL_BUTTON: 'Cancel',
-		SUBMIT_BUTTON: 'Send',
+	BLOCK_IDS: {
+		QUESTION_INPUT: 'question-input-block',
+		QUESTION_DATE: 'question-date-block',
+	},
+	TEXT: {
+		labels: {
+			QUESTION_INPUT: 'Question to ask',
+			QUESTION_DATE: 'Collection date',
+		},
+		placeholders: {
+			QUESTION_INPUT: 'Type your question here...',
+			QUESTION_DATE: 'Select collection date',
+		},
+		titles: {
+			QUESTION_ASK: 'Send Question to Members',
+			CANCEL_BUTTON: 'Cancel',
+			SUBMIT_BUTTON: 'Send',
+			DISMISSED_BUTTON: 'Dismiss',
+			QUESTION_SENT: 'Question Sent',
+		},
 	},
 } as const;
 
-function getQuestionAskModal(appId: string): IUIKitSurfaceViewParam {
-	const blocks: LayoutBlock[] = [
+const getQuestionAskModal = (appId: string): IUIKitSurfaceViewParam => ({
+	id: QUESTION_CONSTANTS.MODAL_IDS.QUESTION_ASK,
+	title: {
+		type: 'plain_text',
+		text: QUESTION_CONSTANTS.TEXT.titles.QUESTION_ASK,
+		emoji: true,
+	},
+	type: UIKitSurfaceType.MODAL,
+	blocks: [
 		{
 			type: 'input',
 			element: {
 				appId,
 				type: 'plain_text_input',
-				blockId: ASK_Q_BLOCK_IDS.QUESTION_INPUT,
-				actionId: ASK_Q_ACTION_IDS.QUESTION_INPUT,
+				blockId: QUESTION_CONSTANTS.BLOCK_IDS.QUESTION_INPUT,
+				actionId: QUESTION_CONSTANTS.ACTION_IDS.QUESTION_INPUT,
 				placeholder: {
 					type: 'plain_text',
-					text: ASK_Q_TEXT.placeholders.QUESTION_INPUT,
+					text: QUESTION_CONSTANTS.TEXT.placeholders.QUESTION_INPUT,
 					emoji: true,
 				},
 				initialValue: '',
@@ -53,61 +61,81 @@ function getQuestionAskModal(appId: string): IUIKitSurfaceViewParam {
 			},
 			label: {
 				type: 'plain_text',
-				text: ASK_Q_TEXT.labels.QUESTION_INPUT,
+				text: QUESTION_CONSTANTS.TEXT.labels.QUESTION_INPUT,
 				emoji: true,
 			},
 		},
 		{
 			type: 'actions',
+			blockId: QUESTION_CONSTANTS.BLOCK_IDS.QUESTION_DATE,
 			elements: [
 				{
 					type: 'datepicker',
 					appId,
 					initialDate: new Date().toISOString().slice(0, 10),
-					blockId: ASK_Q_BLOCK_IDS.QUESTION_DATE,
-					actionId: ASK_Q_ACTION_IDS.QUESTION_DATE,
+					blockId: QUESTION_CONSTANTS.BLOCK_IDS.QUESTION_DATE,
+					actionId: QUESTION_CONSTANTS.ACTION_IDS.QUESTION_DATE,
 					placeholder: {
 						type: 'plain_text',
-						text: ASK_Q_TEXT.placeholders.QUESTION_DATE,
+						text: QUESTION_CONSTANTS.TEXT.placeholders.QUESTION_DATE,
 					},
 				},
 			],
 		},
-	];
-
-	const questionAskModal: IUIKitSurfaceViewParam = {
-		id: ASK_Q_MODAL_IDS.QUESTION_ASK,
-		title: {
+	],
+	submit: {
+		type: BlockElementType.BUTTON,
+		text: {
 			type: 'plain_text',
-			text: ASK_Q_TEXT.titles.QUESTION_ASK,
+			text: QUESTION_CONSTANTS.TEXT.titles.SUBMIT_BUTTON,
 			emoji: true,
 		},
-		type: UIKitSurfaceType.MODAL,
-		blocks,
-		submit: {
-			type: BlockElementType.BUTTON,
+		actionId: QUESTION_CONSTANTS.ACTION_IDS.SUBMIT_QUESTION,
+	} as ButtonElement,
+	close: {
+		type: BlockElementType.BUTTON,
+		text: {
+			type: 'plain_text',
+			text: QUESTION_CONSTANTS.TEXT.titles.CANCEL_BUTTON,
+			emoji: true,
+		},
+		actionId: QUESTION_CONSTANTS.ACTION_IDS.CLOSE_MODAL,
+	} as ButtonElement,
+	clearOnClose: true,
+	notifyOnClose: true,
+	state: {},
+});
+
+const questionSubmittedModal = (appId: string, question: string): IUIKitSurfaceViewParam => ({
+	id: QUESTION_CONSTANTS.MODAL_IDS.QUESTION_ASK,
+	title: {
+		type: 'plain_text',
+		text: QUESTION_CONSTANTS.TEXT.titles.QUESTION_SENT,
+		emoji: true,
+	},
+	type: UIKitSurfaceType.MODAL,
+	blocks: [
+		{
+			type: 'section',
 			text: {
 				type: 'plain_text',
-				text: ASK_Q_TEXT.titles.SUBMIT_BUTTON,
+				text: question,
 				emoji: true,
 			},
-			actionId: ASK_Q_ACTION_IDS.SUBMIT_QUESTION,
-		} as ButtonElement,
-		close: {
-			type: BlockElementType.BUTTON,
-			text: {
-				type: 'plain_text',
-				text: ASK_Q_TEXT.titles.CANCEL_BUTTON,
-				emoji: true,
-			},
-			actionId: ASK_Q_ACTION_IDS.CLOSE_MODAL,
-		} as ButtonElement,
-		clearOnClose: true,
-		notifyOnClose: true,
-		state: {},
-	};
+		},
+	],
+	submit: undefined,
+	close: {
+		type: BlockElementType.BUTTON,
+		text: {
+			type: 'plain_text',
+			text: QUESTION_CONSTANTS.TEXT.titles.DISMISSED_BUTTON,
+			emoji: true,
+		},
+		actionId: QUESTION_CONSTANTS.ACTION_IDS.CLOSE_MODAL,
+	} as ButtonElement,
+	clearOnClose: true,
+	state: {},
+});
 
-	return questionAskModal;
-}
-
-export { getQuestionAskModal, ASK_Q_MODAL_IDS, ASK_Q_ACTION_IDS, ASK_Q_BLOCK_IDS, ASK_Q_TEXT };
+export { getQuestionAskModal, questionSubmittedModal, QUESTION_CONSTANTS };

--- a/modals/QuestionAskModal.ts
+++ b/modals/QuestionAskModal.ts
@@ -1,0 +1,113 @@
+import { IUIKitSurfaceViewParam } from '@rocket.chat/apps-engine/definition/accessors';
+import { UIKitSurfaceType } from '@rocket.chat/apps-engine/definition/uikit';
+import { BlockElementType, ButtonElement, LayoutBlock } from '@rocket.chat/ui-kit';
+
+const ASK_Q_MODAL_IDS = {
+	QUESTION_ASK: 'question-ask-modal',
+} as const;
+
+const ASK_Q_ACTION_IDS = {
+	QUESTION_INPUT: 'question-input-action',
+	QUESTION_DATE: 'question-date-action',
+	SUBMIT_QUESTION: 'submit-question',
+	CLOSE_MODAL: 'close-modal',
+} as const;
+
+const ASK_Q_BLOCK_IDS = {
+	QUESTION_INPUT: 'question-input-block',
+	QUESTION_DATE: 'question-date-block',
+} as const;
+
+const ASK_Q_TEXT = {
+	labels: {
+		QUESTION_INPUT: 'Question to ask',
+		QUESTION_DATE: 'Collection date',
+	},
+	placeholders: {
+		QUESTION_INPUT: 'Type your question here...',
+		QUESTION_DATE: 'Select collection date',
+	},
+	titles: {
+		QUESTION_ASK: 'Send Question to Members',
+		CANCEL_BUTTON: 'Cancel',
+		SUBMIT_BUTTON: 'Send',
+	},
+} as const;
+
+function getQuestionAskModal(appId: string): IUIKitSurfaceViewParam {
+	const blocks: LayoutBlock[] = [
+		{
+			type: 'input',
+			element: {
+				appId,
+				type: 'plain_text_input',
+				blockId: ASK_Q_BLOCK_IDS.QUESTION_INPUT,
+				actionId: ASK_Q_ACTION_IDS.QUESTION_INPUT,
+				placeholder: {
+					type: 'plain_text',
+					text: ASK_Q_TEXT.placeholders.QUESTION_INPUT,
+					emoji: true,
+				},
+				initialValue: '',
+				multiline: true,
+			},
+			label: {
+				type: 'plain_text',
+				text: ASK_Q_TEXT.labels.QUESTION_INPUT,
+				emoji: true,
+			},
+		},
+		{
+			type: 'actions',
+			elements: [
+				{
+					type: 'datepicker',
+					appId,
+					initialDate: new Date().toISOString().slice(0, 10),
+					blockId: ASK_Q_BLOCK_IDS.QUESTION_DATE,
+					actionId: ASK_Q_ACTION_IDS.QUESTION_DATE,
+					placeholder: {
+						type: 'plain_text',
+						text: ASK_Q_TEXT.placeholders.QUESTION_DATE,
+					},
+				},
+			],
+		},
+	];
+
+	const questionAskModal: IUIKitSurfaceViewParam = {
+		id: ASK_Q_MODAL_IDS.QUESTION_ASK,
+		title: {
+			type: 'plain_text',
+			text: ASK_Q_TEXT.titles.QUESTION_ASK,
+			emoji: true,
+		},
+		type: UIKitSurfaceType.MODAL,
+		blocks,
+		submit: {
+			type: BlockElementType.BUTTON,
+			text: {
+				type: 'plain_text',
+				text: ASK_Q_TEXT.titles.SUBMIT_BUTTON,
+				emoji: true,
+			},
+			actionId: ASK_Q_ACTION_IDS.SUBMIT_QUESTION,
+		} as ButtonElement,
+		close: {
+			type: BlockElementType.BUTTON,
+			text: {
+				type: 'plain_text',
+				text: ASK_Q_TEXT.titles.CANCEL_BUTTON,
+				emoji: true,
+			},
+			actionId: ASK_Q_ACTION_IDS.CLOSE_MODAL,
+		} as ButtonElement,
+		clearOnClose: true,
+		notifyOnClose: true,
+		state: {},
+	};
+
+	return questionAskModal;
+}
+
+export { getQuestionAskModal, ASK_Q_MODAL_IDS, ASK_Q_ACTION_IDS, ASK_Q_BLOCK_IDS, ASK_Q_TEXT };

--- a/types/AskQuestion.ts
+++ b/types/AskQuestion.ts
@@ -1,3 +1,5 @@
+import { IMessageAttachment } from '@rocket.chat/apps-engine/definition/messages';
+
 export type QuestionPayload = {
 	text: string;
 	collectionDate: string;
@@ -8,10 +10,11 @@ export type QuestionPayload = {
 };
 
 export type ResponsePayload = {
-	response: string;
+	response: string | undefined;
 	questionId: string;
 	questionText: string;
 	userId: string;
 	roomId: string;
 	msgId: string;
+	attachments?: Array<IMessageAttachment>;
 };

--- a/types/AskQuestion.ts
+++ b/types/AskQuestion.ts
@@ -1,0 +1,7 @@
+export type QuestionPayload = {
+	text: string;
+	collectionDate: string;
+	askedBy: string;
+	timestamp: string;
+	msgIds: string[];
+};

--- a/types/AskQuestion.ts
+++ b/types/AskQuestion.ts
@@ -4,4 +4,5 @@ export type QuestionPayload = {
 	askedBy: string;
 	timestamp: string;
 	msgIds: string[];
+	state: 'pending' | 'sent' | 'closed';
 };

--- a/types/AskQuestion.ts
+++ b/types/AskQuestion.ts
@@ -6,3 +6,12 @@ export type QuestionPayload = {
 	msgIds: string[];
 	state: 'pending' | 'sent' | 'closed';
 };
+
+export type ResponsePayload = {
+	response: string;
+	questionId: string;
+	questionText: string;
+	userId: string;
+	roomId: string;
+	msgId: string;
+};


### PR DESCRIPTION
- Introduces a new slash command `/koko question` for sending out questions to all the members (members from the room mentioned in the setting)
- Plan was to use this for collecting image responses from users, but can be used to collect text responses or a mix of both
- Introduces a new permission for reading server URL to construct the message forward link
- The error for the date is shown on the input block, since the error text won't show up near the datepicker, might be a bug or expected behavior on the UIKit's element.
- Once the modal is submitted the messages will be sent via a scheduler 10 seconds later
- Collection is done at the Submitted date 12 AM UTC