### PR TITLE
fix: koko photo mission logs

### DIFF
--- a/KokoApp.ts
+++ b/KokoApp.ts
@@ -434,11 +434,17 @@ export class KokoApp extends App implements IUIKitInteractionHandler, IPostMessa
 		persistence: IPersistence,
 		modify: IModify,
 	): Promise<void> {
-		const appUser = await read.getUserReader().getAppUser(this.getID());
+		const appUser = this.botUser || (await read.getUserReader().getByUsername(this.botUsername));
 
 		if (!AskQuestionHelper.isMessageIntendedForBot(message, appUser)) {
+			// if message is from the bot user, log and return
+			this.getLogger().debug(
+				`Message ${message?.threadId} is not intended for the bot. Sender: ${message.sender?.username}, ${message.sender?.id}, Room: ${JSON.stringify(message?.room)}, App User: ${JSON.stringify(appUser)}`,
+			);
 			return;
 		}
+
+		this.getLogger().debug('Processing message response');
 
 		try {
 			const parentMessage = await read.getMessageReader().getById(message.threadId as string);

--- a/actions/KokoAskQuestion.ts
+++ b/actions/KokoAskQuestion.ts
@@ -72,7 +72,11 @@ export class KokoAskQuestion {
 			};
 
 			// send after a minute
-			const sendTime = new Date().setSeconds(new Date().getSeconds() + 10);
+			const sendTime = new Date().setSeconds(new Date().getSeconds() + 60);
+
+			this.app
+				.getLogger()
+				.info(`Scheduling question "${questionText}" for ${sendTime}; current time is ${new Date()}`);
 
 			// Encode the question text to create a unique ID
 			const questionId = Buffer.from(questionText?.trim(), 'utf-8').toString('base64');
@@ -108,6 +112,7 @@ export class KokoAskQuestion {
 		}
 
 		try {
+			this.app.getLogger().debug(`ask-question processor: ${questionAssocId}`);
 			// Load the saved question
 			const assoc = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, questionAssocId);
 			const [saved] = (await read.getPersistenceReader().readByAssociation(assoc)) as QuestionPayload[];
@@ -136,6 +141,8 @@ export class KokoAskQuestion {
 
 			// Fetch members and send
 			const members = await getMembers(this.app, read);
+
+			this.app.getLogger().debug(`ask-question processor: members ${members.length}`);
 			const messageIds: string[] = [];
 			const finisher = modify.getCreator();
 
@@ -145,6 +152,7 @@ export class KokoAskQuestion {
 				}
 				const room = await getDirect(this.app, read, modify, member.username);
 				if (!room) {
+					this.app.getLogger().error(`ask-question processor: no room for ${member.username}`);
 					continue;
 				}
 
@@ -158,18 +166,28 @@ export class KokoAskQuestion {
 					.setRoom(room)
 					.setText(highlightedText);
 
-				const msgId = await finisher.finish(firstMsg);
-				messageIds.push(msgId);
+				try {
+					const msgId = await finisher.finish(firstMsg);
+					messageIds.push(msgId);
 
-				// Then, the deadline/top‐level info (in thread)
-				const infoMsg = finisher
-					.startMessage()
-					.setSender(this.app.botUser)
-					.setRoom(room)
-					.setText(`*Deadline:* ${formattedDate}\nReply below in the thread to submit your answer`)
-					.setThreadId(msgId);
+					this.app
+						.getLogger()
+						.debug(`ask-question processor: sent question to ${member.username} (${msgId})`);
+					// Then, the deadline/top‐level info (in thread)
+					const infoMsg = finisher
+						.startMessage()
+						.setSender(this.app.botUser)
+						.setRoom(room)
+						.setText(`*Deadline:* ${formattedDate}\nReply below in the thread to submit your answer`)
+						.setThreadId(msgId);
 
-				await finisher.finish(infoMsg);
+					await finisher.finish(infoMsg);
+				} catch (error) {
+					this.app
+						.getLogger()
+						.error(`ask-question processor: error sending message to ${member.username}`, error);
+					continue;
+				}
 			}
 
 			// Persist the sent message IDs and mark “sent”
@@ -185,7 +203,7 @@ export class KokoAskQuestion {
 				data: { questionAssocId },
 			});
 		} catch (err) {
-			this.app.getLogger().error(`Error in ask-question processor: ${err.message}`);
+			this.app.getLogger().error(`Error in ask-question processor`, err);
 		}
 	}
 

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "b9970f61-06ac-46e4-ade3-3b0f0c667739",
-    "version": "1.0.4",
+    "version": "1.2.4",
     "requiredApiVersion": "^1.49.0",
     "iconFile": "icon.png",
     "author": {

--- a/commands/Question.ts
+++ b/commands/Question.ts
@@ -2,10 +2,16 @@ import { IModify, IPersistence, IRead } from '@rocket.chat/apps-engine/definitio
 import { SlashCommandContext } from '@rocket.chat/apps-engine/definition/slashcommands';
 import { KokoApp } from '../KokoApp';
 import { questionModal } from '../modals/QuestionModal';
-import { hasValidRole } from '../lib/helpers';
+import { hasValidRole, notifyUser } from '../lib/helpers';
 import { getQuestionAskModal } from '../modals/QuestionAskModal';
+import { IUser } from '@rocket.chat/apps-engine/definition/users';
 
 // tslint:disable-next-line:max-line-length
+enum QuestionSubcommand {
+	REPOST = 'repost',
+	INFO = 'info',
+}
+
 export async function processQuestionCommand(
 	app: KokoApp,
 	context: SlashCommandContext,
@@ -13,22 +19,104 @@ export async function processQuestionCommand(
 	modify: IModify,
 	persistence: IPersistence,
 ): Promise<void> {
+	const args = context.getArguments();
 	const triggerId = context.getTriggerId();
 	const sender = context.getSender();
 	const room = context.getRoom();
 
-	if (triggerId) {
-		try {
-			if (await hasValidRole(read, sender.roles, app.managerRolesMap)) {
-				// Handle the manager role show them a Modal to ship the question
-				const questionAskModal = getQuestionAskModal(app.getID());
-				await modify.getUiController().openSurfaceView(questionAskModal, { triggerId }, context.getSender());
-				return;
-			}
-			const modal = await questionModal({ read, modify, data: { user: context.getSender() } });
-			await modify.getUiController().openModalView(modal, { triggerId }, context.getSender());
-		} catch (error) {
-			console.log(error);
+	// Show question modal if no arguments provided
+	if (args.length === 1 && triggerId) {
+		return handleQuestionModal(app, context, read, modify, sender, triggerId);
+	}
+
+	const [_command, subcommand, ...params] = args;
+
+	try {
+		switch (subcommand?.toLowerCase()) {
+			case QuestionSubcommand.REPOST:
+				await handleRepost(app, read, modify, persistence, room, sender, params);
+				break;
+
+			case QuestionSubcommand.INFO:
+				await handleInfo(app, read, modify, persistence, room, sender, params);
+				break;
+
+			default:
+				await showHelp(app, modify, room, sender);
 		}
+	} catch (error) {
+		app.getLogger().error('Error processing question command:', error);
+		await notifyUser(app, modify, room, sender, `Error: ${error.message}`);
+	}
+}
+
+async function handleRepost(
+	app: KokoApp,
+	read: IRead,
+	modify: IModify,
+	persistence: IPersistence,
+	room: any,
+	sender: IUser,
+	params: string[],
+): Promise<void> {
+	const [questionId, roomName] = params;
+	if (!questionId) {
+		throw new Error('Please provide a question ID to repost');
+	}
+
+	const roomNameWithoutHash = roomName?.startsWith('#') ? roomName.substring(1) : roomName;
+	const postRoomName = roomNameWithoutHash || room.slugifiedName;
+	await app.kokoQuestionAsk.postAnswers(read, modify, persistence, questionId, postRoomName);
+}
+
+async function handleInfo(
+	app: KokoApp,
+	read: IRead,
+	modify: IModify,
+	persistence: IPersistence,
+	room: any,
+	sender: IUser,
+	params: string[],
+): Promise<void> {
+	const questionText = params.join(' ');
+	if (!questionText) {
+		throw new Error('Please provide a question text to show its details');
+	}
+
+	await app.kokoQuestionAsk.showQuestionInfoByText(read, modify, persistence, questionText, room.id);
+}
+
+async function showHelp(app: KokoApp, modify: IModify, room: any, sender: IUser): Promise<void> {
+	await notifyUser(
+		app,
+		modify,
+		room,
+		sender,
+		'Available subcommands:\n' +
+			'`/koko question` - Create a new question\n' +
+			'`/koko question info <questionText>` - Show question details\n' +
+			'`/koko question repost <questionId> [roomName]` - Repost question answers',
+	);
+}
+
+async function handleQuestionModal(
+	app: KokoApp,
+	context: SlashCommandContext,
+	read: IRead,
+	modify: IModify,
+	sender: IUser,
+	triggerId: string,
+): Promise<void> {
+	try {
+		if (await hasValidRole(read, sender.roles, app.managerRolesMap)) {
+			const questionAskModal = getQuestionAskModal(app.getID());
+			await modify.getUiController().openSurfaceView(questionAskModal, { triggerId }, sender);
+			return;
+		}
+		const modal = await questionModal({ read, modify, data: { user: sender } });
+		await modify.getUiController().openModalView(modal, { triggerId }, sender);
+	} catch (error) {
+		app.getLogger().error('Error opening question modal:', error);
+		await notifyUser(app, modify, context.getRoom(), sender, 'Error opening question modal: ' + error.message);
 	}
 }


### PR DESCRIPTION
- Adds more logs for easier debugging in case of errors
- The cause for the App not working was some DMs being read-only, and sending messages throws an error, ending the scheduled job
- Fixes Koko App not recording submitted answers, since on the Open server, Koko App had 2 users with different IDs, causing the check to fail, when the App user was passed
- Increase the wait time to 60 seconds 