### PR TITLE
fix: Koko multiple thanks notification

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "b9970f61-06ac-46e4-ade3-3b0f0c667739",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "requiredApiVersion": "^1.49.0",
     "iconFile": "icon.png",
     "author": {

--- a/modals/PraiseModal.ts
+++ b/modals/PraiseModal.ts
@@ -119,6 +119,7 @@ export async function praiseRegisteredModal({
 				text: 'Dismiss',
 			},
 		}),
+		submit: undefined,
 		blocks: block.getBlocks(),
 	};
 }

--- a/modals/ValuesModal.ts
+++ b/modals/ValuesModal.ts
@@ -159,6 +159,7 @@ export async function valuesRegisteredModal({
 				text: 'Dismiss',
 			},
 		}),
+		submit: undefined,
 		blocks: block.getBlocks(),
 	};
 }


### PR DESCRIPTION
### Problem  
After submitting a praise, Koko's confirmation modal included a "Submit" button.  
If clicked (intentionally or accidentally), it could resend the same praise multiple times, resulting in duplicate submissions.

While sending more praise is generally positive, duplicate entries are not desirable.

### Fix  
- Removed the redundant "Submit" (titled "Praise") button from the confirmation modal to prevent duplicate praises.


#### Additional links
[CA2-70](https://rocketchat.atlassian.net/browse/CA2-70)

[CA2-70]: https://rocketchat.atlassian.net/browse/CA2-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ